### PR TITLE
Fixed image width

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -122,6 +122,7 @@ button {
   img {
     align-self: center;
     border-radius: 0.5rem;
+    max-width: 18.75rem;
   }
 
   ul {


### PR DESCRIPTION
Some images served by Edamam are very large. Although uncommon, this needs to be accounted for in the CSS